### PR TITLE
Update Navigation Demo to Include latest URDF

### DIFF
--- a/euler_navigation/params/costmap_common.yaml
+++ b/euler_navigation/params/costmap_common.yaml
@@ -6,13 +6,13 @@ obstacle_layer:
     laser1: 
         topic: /euler/scan1
         data_type: LaserScan
-        sensor_frame: /robot_0/base_laser_link
+        sensor_frame: /front_sick_s300
         clearing: true
         marking: true
     laser2:
         topic: /euler/scan2
         data_type: LaserScan
-        sensor_frame: /robot_1/base_laser_link
+        sensor_frame: /rear_sick_s300
         clearing: true
         marking: true
     obstacle_range: 10

--- a/euler_navigation/params/move_base.yaml
+++ b/euler_navigation/params/move_base.yaml
@@ -9,7 +9,7 @@ global_costmap:
     - {name: static_layer, type: 'costmap_2d::StaticLayer'}
     - {name: obstacle_layer, type: 'costmap_2d::ObstacleLayer'}
     - {name: inflation_layer, type: 'costmap_2d::InflationLayer'}
-    robot_base_frame: /base_footprint
+    robot_base_frame: /vetex_base_footprint
 local_costmap:
     plugins:
     - {name: obstacle_layer, type: 'costmap_2d::ObstacleLayer'}
@@ -17,6 +17,6 @@ local_costmap:
     origin_x: -5
     origin_y: -5
     global_frame: /odom
-    robot_base_frame: /base_footprint
+    robot_base_frame: /vetex_base_footprint
     rolling_window: true
 

--- a/euler_navigation_demo/euler.world
+++ b/euler_navigation_demo/euler.world
@@ -20,12 +20,12 @@ define topurg ranger
 define laser_assembly position
 (
   size [0.01 0.01 0.01]
-  topurg(pose [ -1.2192 -.6096 .26 225.000 ])
+  topurg(pose [ -1.2361 .617 0.522 -227.000 ])
 )
 
 define euler position
 (
-  size [2.4384 1.2192 0.25]
+  size [2.4384 1.2192 0.532]
 
   # [ xmin xmax ymin ymax zmin zmax amin amax ]
   velocity_bounds     [-1 1 -0.8 0.8 0 0 -28 28 ]
@@ -34,8 +34,9 @@ define euler position
   origin [0 0 0 0]
   gui_nose 1
   drive "omni"
-  topurg(pose [ 1.2192 .6096 .26 45.000 ])
-  laser_assembly(pose [0 0 .26 0])
+  
+  topurg(pose [ 1.2369 -.617 0 -43.000 ])
+  laser_assembly(pose [0 0 0 0])
 )
 
 

--- a/euler_navigation_demo/launch/stage.launch
+++ b/euler_navigation_demo/launch/stage.launch
@@ -24,7 +24,7 @@
     <node name="rviz" pkg="rviz" type="rviz" args="-d $(find euler_navigation)/euler_nav.rviz"/>
     
     
-    <param name="robot_description" command="$(find xacro)/xacro.py $(find vetex_support)/urdf/vetex.xacro" />
+    <param name="robot_description" command="$(find xacro)/xacro.py $(find euler_support)/urdf/euler.xacro" />
     <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
     <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
 

--- a/euler_navigation_demo/launch/stage.launch
+++ b/euler_navigation_demo/launch/stage.launch
@@ -18,7 +18,7 @@
     <node name="fake_localization" pkg="fake_localization" type="fake_localization" output="screen">
         <remap from="/base_pose_ground_truth" to="/euler/base_pose_ground_truth"/>
         <param name="odom_frame_id" value="/robot_0/odom"/>
-        <param name="base_frame_id" value="/base_footprint"/>
+        <param name="base_frame_id" value="/vetex_base_footprint"/>
     </node>
     <include file="$(find euler_navigation)/launch/move_base.launch"/>
     <node name="rviz" pkg="rviz" type="rviz" args="-d $(find euler_navigation)/euler_nav.rviz"/>

--- a/euler_support/urdf/euler_macro.xacro
+++ b/euler_support/urdf/euler_macro.xacro
@@ -82,7 +82,6 @@
         </link>
         <link name="${prefix}front_sick_s300">
                 <visual>
-                        <origin xyz="0.193 -0.617 0.532" rpy="0 0 -0.75047" />
                         <geometry>
                                 <mesh filename="package://euler_support/meshes/visual/sick_s300_mounting_assy.stl" />
                         </geometry>
@@ -91,7 +90,6 @@
                         </material>
                 </visual>
                 <collision>
-                        <origin xyz="0.193 0.617 0.532" rpy="0 0 -0.75047" />
                         <geometry>
                                 <mesh filename="package://euler_support/meshes/collision/sick_s300_mounting_assy.stl" />
                         </geometry>
@@ -99,7 +97,6 @@
         </link>
         <link name="${prefix}rear_sick_s300">
                 <visual>
-                        <origin xyz="-2.280 0.617 0.532" rpy="0 0  -3.96178" />
                         <geometry>
                                 <mesh filename="package://euler_support/meshes/visual/sick_s300_mounting_assy.stl" />
                         </geometry>
@@ -108,7 +105,6 @@
                         </material>
                 </visual>
                 <collision>
-                        <origin xyz="-2.280 -0.617 0.532" rpy="0 0 -3.96178" />
                         <geometry>
                                 <mesh filename="package://euler_support/meshes/collision/sick_s300_mounting_assy.stl" />
                         </geometry>
@@ -156,13 +152,13 @@
         <joint name="${prefix}front_sick_s300" type="fixed">
                 <parent link="${prefix}base_link" />
                 <child link="${prefix}front_sick_s300" />
-                <origin xyz="0 0 0" rpy="0 0 0" />
+                <origin xyz="0.193 -0.617 0.532" rpy="0 0 -0.75047" />
                 <axis xyz="0 0 0" />
         </joint>
                 <joint name="${prefix}rear_sick_s300" type="fixed">
                 <parent link="${prefix}base_link" />
                 <child link="${prefix}rear_sick_s300" />
-                <origin xyz="0 0 0" rpy="0 0 0" />
+                <origin xyz="-2.280 0.617 0.532" rpy="0 0  -3.96178" />
                 <axis xyz="0 0 0" />
         </joint>
 </xacro:macro>

--- a/vetex_support/urdf/vetex_macro.xacro
+++ b/vetex_support/urdf/vetex_macro.xacro
@@ -17,7 +17,7 @@
                                 </geometry>
                         </collision>
                 </link>
-                <link name="base_footprint"/>
+                <link name="${prefix}base_footprint"/>
                 <link name="${prefix}left_front_wheel">
                         <visual>
                                 <geometry>
@@ -79,7 +79,7 @@
                 <joint name="${prefix}to_footprint" type="fixed">
                     <origin xyz="-1.0439 0 0"/>
                     <parent link="${prefix}base_link" />
-                    <child link="base_footprint" />
+                    <child link="${prefix}base_footprint" />
                 </joint>
                 <joint name="${prefix}left_front_wheel" type="continuous">
                         <origin xyz="0 0.58668 0.21577" rpy="0 1 0" />

--- a/vetex_support/urdf/vetex_macro.xacro
+++ b/vetex_support/urdf/vetex_macro.xacro
@@ -17,7 +17,7 @@
                                 </geometry>
                         </collision>
                 </link>
-                <link name="${prefix}base_footprint"/>
+                <link name="base_footprint"/>
                 <link name="${prefix}left_front_wheel">
                         <visual>
                                 <geometry>
@@ -79,7 +79,7 @@
                 <joint name="${prefix}to_footprint" type="fixed">
                     <origin xyz="-1.0439 0 0"/>
                     <parent link="${prefix}base_link" />
-                    <child link="${prefix}base_footprint" />
+                    <child link="base_footprint" />
                 </joint>
                 <joint name="${prefix}left_front_wheel" type="continuous">
                         <origin xyz="0 0.58668 0.21577" rpy="0 1 0" />


### PR DESCRIPTION
- Loads the latest URDF from euler_support package. 
- Changes the urdf in two ways
  - Removes the prefix from the base_footprint frame, so when used in the macro, it appears as base_footprint, not vetex_base_footprint
  - Changes the origin of the S300 scanners to be at the laser scanner itself. 
- Update the Navigation configuration to match the new URDF frame names for the S300 scanners. 
- Updates the Stage simulation to reflect the true location of the lasers. 
