### PR TITLE
Fix for issue #12: empty run_depend in euler_support package manifest

### DIFF
--- a/euler_support/package.xml
+++ b/euler_support/package.xml
@@ -37,7 +37,7 @@
  <url type="repository">https://github.com/swri-robotics/euler</url>
  <buildtool_depend>catkin</buildtool_depend>
  <build_depend>roslaunch</build_depend>
- <run_depend></run_depend>
+ <run_depend>xacro</run_depend>
  <run_depend>robot_state_publisher</run_depend>
  <run_depend>rviz</run_depend>
  <run_depend>joint_state_publisher</run_depend>


### PR DESCRIPTION
Package was missing dependency on xacro, so re-use empty run_depend tag for that.
