### PR TITLE
Additional run depends

### DIFF
--- a/euler_navigation/package.xml
+++ b/euler_navigation/package.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" ?>
+<?xml version="1.0"?>
 <package>
   <name>euler_navigation</name>
   <version>0.0.0</version>

--- a/euler_navigation_demo/package.xml
+++ b/euler_navigation_demo/package.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" ?>
+<?xml version="1.0"?>
 <package>
   <name>euler_navigation_demo</name>
   <version>0.0.0</version>
@@ -15,4 +15,8 @@
   <run_depend>rviz</run_depend>
   <run_depend>stage_ros</run_depend>
   <run_depend>tf</run_depend>
+  <run_depend>euler_support</run_depend>
+  <run_depend>joint_state_publisher</run_depend>
+  <run_depend>robot_state_publisher</run_depend>
+  <run_depend>xacro</run_depend>
 </package>

--- a/motoman_mh5lf_support/package.xml
+++ b/motoman_mh5lf_support/package.xml
@@ -40,8 +40,8 @@
  <run_depend>robot_state_publisher</run_depend>
  <run_depend>rviz</run_depend>
  <run_depend>joint_state_publisher</run_depend>
-  <run_depend>industrial_robot_client</run_depend>
-  <run_depend>xacro</run_depend>
+ <run_depend>industrial_robot_client</run_depend>
+ <run_depend>xacro</run_depend>
  <export>
   <architecture_independent/>
  </export>

--- a/motoman_mh5lf_support/package.xml
+++ b/motoman_mh5lf_support/package.xml
@@ -1,4 +1,3 @@
-
 <package>
  <name>motoman_mh5lf_support</name>
  <version>0.0.0</version>
@@ -41,6 +40,8 @@
  <run_depend>robot_state_publisher</run_depend>
  <run_depend>rviz</run_depend>
  <run_depend>joint_state_publisher</run_depend>
+  <run_depend>industrial_robot_client</run_depend>
+  <run_depend>xacro</run_depend>
  <export>
   <architecture_independent/>
  </export>

--- a/vetex_support/CMakeLists.txt
+++ b/vetex_support/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(vetex_support)
+
+find_package(catkin REQUIRED)
+
+catkin_package()
+

--- a/vetex_support/manifest.xml
+++ b/vetex_support/manifest.xml
@@ -1,6 +1,0 @@
-<package>
-  <description brief="vetex_support">vetex_support</description>
-  <depend package="gazebo" />
-  <author>Paul Hvass</author>
-  <license>BSD</license>
-</package>

--- a/vetex_support/package.xml
+++ b/vetex_support/package.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<package>
+  <name>vetex_support</name>
+  <version>0.0.0</version>
+  <description>The vetex_support package</description>
+  <maintainer email="paul.hvass@swri.org">Paul Hvass</maintainer>
+  <author>Paul Hvass</author>
+  <license>BSD</license>
+  <buildtool_depend>catkin</buildtool_depend>
+</package>

--- a/vetex_support/package.xml
+++ b/vetex_support/package.xml
@@ -7,4 +7,14 @@
   <author>Paul Hvass</author>
   <license>BSD</license>
   <buildtool_depend>catkin</buildtool_depend>
+  <run_depend>Vetex_Mobile_Platform</run_depend>
+  <run_depend>gazebo</run_depend>
+  <run_depend>gazebo_worlds</run_depend>
+  <run_depend>joint_state_publisher</run_depend>
+  <run_depend>pr2_controller_manager</run_depend>
+  <run_depend>robot_state_publisher</run_depend>
+  <run_depend>rostopic</run_depend>
+  <run_depend>rviz</run_depend>
+  <run_depend>tf</run_depend>
+  <run_depend>xacro</run_depend>
 </package>


### PR DESCRIPTION
To be merged after #15. 

Follow up questions though: 
- Has industrial_robot_client been released for indigo? 
- Where does the Vetex_Mobile_Platform package live? 
- Why does the vetex seem to use pr2_controller_manager instead of the more general controller_manager?
