### PR TITLE
sleeps briefly before exiting the node in order to stop the base

### DIFF
--- a/vetex_driver/src/vetex_driver.cpp
+++ b/vetex_driver/src/vetex_driver.cpp
@@ -58,6 +58,7 @@ public:
 	  }
     
     setEnable(false);
+    ros::Duration(1.0f).sleep();
 	  vetex_terminate();
 
     return true;
@@ -95,9 +96,10 @@ protected:
   void setEnable(bool enable)
   {
     if(enable)
-    {
+    {      
+      vetex_enable_movement();         
+      ros::Duration(0.5f).sleep();   
       vetex_set_all_percentages(0, 0, 0);
-      vetex_enable_movement();
       ROS_INFO_STREAM("Movement enabled");
       enabled_ = true;
     }


### PR DESCRIPTION
Small improvements to the vetex driver:
- Sleeps briefly after the vetex_enable_movement() call before sending the zero velocity command.
